### PR TITLE
Translate Spark's timestamp() to Trino's from_unixtime()

### DIFF
--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -431,12 +431,14 @@ def remove_quotes_around_0x_strings(query):
     substituted = re.sub(pattern, r"0x\1", query, flags=re.IGNORECASE)
     return substituted
 
+
 def spark_function_replacements(node):
     """Replace the Spark timestamp() function with Trino's from_unixtime() function"""
     query = node.sql(dialect="trino")
     if "timestamp(" in query.lower():
         query = re.sub("timestamp", "from_unixtime", query, flags=re.IGNORECASE)
     return sqlglot.parse_one(query, read="trino")
+
 
 def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.

--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -224,7 +224,6 @@ def interval_fix(node):
 
         # The interval value is most likely a string, like `interval '1 week'`
         value, granularity, *rest = interval_argument.split()
-        1 + 1
         if any(
             known_granularity in granularity.lower()
             for known_granularity in [
@@ -432,6 +431,12 @@ def remove_quotes_around_0x_strings(query):
     substituted = re.sub(pattern, r"0x\1", query, flags=re.IGNORECASE)
     return substituted
 
+def spark_function_replacements(node):
+    """Replace the Spark timestamp() function with Trino's from_unixtime() function"""
+    query = node.sql(dialect="trino")
+    if "timestamp(" in query.lower():
+        query = re.sub("timestamp", "from_unixtime", query, flags=re.IGNORECASE)
+    return sqlglot.parse_one(query, read="trino")
 
 def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
@@ -446,6 +451,7 @@ def spark_transforms(query):
         warn_unnest,
         warn_sequence,
         bytea2numeric,
+        spark_function_replacements,
     )
     for f in transforms:
         query_tree = query_tree.transform(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-harmonizer"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -34,4 +34,5 @@ spark_test_cases = [
     SparkTestCase("test_cases/spark/quoted_column.in", "test_cases/spark/quoted_column.out"),
     SparkTestCase("test_cases/spark/0x_strings.in", "test_cases/spark/0x_strings.out"),
     SparkTestCase("test_cases/spark/interval_week.in", "test_cases/spark/interval_week.out"),
+    SparkTestCase("test_cases/spark/timestamp.in", "test_cases/spark/timestamp.out"),
 ]

--- a/tests/test_cases/spark/timestamp.in
+++ b/tests/test_cases/spark/timestamp.in
@@ -1,0 +1,1 @@
+select timestamp(n)

--- a/tests/test_cases/spark/timestamp.out
+++ b/tests/test_cases/spark/timestamp.out
@@ -1,0 +1,4 @@
+/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
+
+SELECT
+  FROM_UNIXTIME(n)


### PR DESCRIPTION
The equivalent of [Spark's `timestamp()`](https://spark.apache.org/docs/2.3.0/api/sql/index.html) on Trino is [`from_unixtime`](https://trino.io/docs/current/functions/datetime.html)