### PR TITLE
Add and use Dunesql dialect

### DIFF
--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -1,5 +1,6 @@
-from sqlglot.dialects.trino import Trino
 from sqlglot import exp
+from sqlglot.dialects.trino import Trino
+
 
 class DuneSQL(Trino):
     class Tokenizer(Trino.Tokenizer):

--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -3,6 +3,10 @@ from sqlglot.dialects.trino import Trino
 
 
 class DuneSQL(Trino):
+    """The DuneSQL dialect is the dialect used to execute SQL queries on Dune's crypto data sets
+
+    DuneSQL is the Trino dialect with slight modifications."""
+
     class Tokenizer(Trino.Tokenizer):
         """Text -> Tokens"""
 

--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -7,7 +7,7 @@ class DuneSQL(Trino):
 
     class Generator(Trino.Generator):
         TRANSFORMS = Trino.Generator.TRANSFORMS | {
-            # this transform will ensure that hex strings are always outputed as 0xdeadbeef,
-            # and not as X'deadbeef'
+            # this transform will ensure that hex strings are always
+            # output as 0xdeadbeef, and not as X'deadbeef'
             exp.HexString: lambda self, e: hex(int(e.name)),
         }

--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -10,7 +10,7 @@ class DuneSQL(Trino):
     class Tokenizer(Trino.Tokenizer):
         """Text -> Tokens"""
 
-        HEX_STRINGS = ["0x", ("X’", "‘")]
+        HEX_STRINGS = ["0x", ("X'", "'")]
 
     class Parser(Trino.Parser):
         """Tokens -> AST"""

--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -4,11 +4,19 @@ from sqlglot.dialects.trino import Trino
 
 class DuneSQL(Trino):
     class Tokenizer(Trino.Tokenizer):
-        HEX_STRINGS = ["0x", ("X'", "'")]
+        """Text -> Tokens"""
+
+        HEX_STRINGS = ["0x", ("X’", "‘")]
+
+    class Parser(Trino.Parser):
+        """Tokens -> AST"""
+
+        pass
 
     class Generator(Trino.Generator):
+        """AST -> SQL"""
+
         TRANSFORMS = Trino.Generator.TRANSFORMS | {
-            # this transform will ensure that hex strings are always
-            # output as 0xdeadbeef, and not as X'deadbeef'
+            # Output hex strings as 0xdeadbeef
             exp.HexString: lambda self, e: hex(int(e.name)),
         }

--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -1,0 +1,11 @@
+from sqlglot.dialects.trino import Trino
+from sqlglot import exp
+
+class DuneSQL(Trino):
+    class Tokenizer(Trino.Tokenizer):
+        HEX_STRINGS = ["0x", ("X'", "'")]
+
+    class Generator(Trino.Generator):
+        TRANSFORMS = Trino.Generator.TRANSFORMS | {
+            exp.HexString: lambda self, e: hex(int(e.name)),
+        }

--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -7,5 +7,7 @@ class DuneSQL(Trino):
 
     class Generator(Trino.Generator):
         TRANSFORMS = Trino.Generator.TRANSFORMS | {
+            # this transform will ensure that hex strings are always outputed as 0xdeadbeef,
+            # and not as X'deadbeef'
             exp.HexString: lambda self, e: hex(int(e.name)),
         }

--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -14,6 +14,7 @@ from dune.harmonizer.custom_transforms import (
     remove_quotes_around_0x_strings,
     spark_transforms,
 )
+from dune.harmonizer.dialects.dunesql import DuneSQL
 from dune.harmonizer.errors import DuneTranslationError
 
 
@@ -45,7 +46,7 @@ def _translate_query(query, sqlglot_dialect, dataset=None):
             query_tree = postgres_transforms(query, dataset)
 
         # Turn back to SQL
-        query = query_tree.sql(dialect="trino", pretty=True)
+        query = query_tree.sql(dialect=DuneSQL, pretty=True)
 
         # Replace placeholders with Dune params again
         for replace, original in parameter_map.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-harmonizer"
-version = "0.4.1"
+version = "0.5.0"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,17 +6,6 @@ def canonicalize(multiline_string):
     return " ".join(line.strip() for line in multiline_string.split("\n")).lower()
 
 
-def assert_output(output, expected_output):
-    clean_output = canonicalize(output)
-    if clean_output != expected_output:
-        print("== got ==")
-        print(clean_output)
-        print()
-        print("== expected ==")
-        print(expected_output)
-    assert clean_output == expected_output
-
-
 def read_test_case(testcase):
     p = Path(__file__).parent
     in_filename = p / testcase.in_filename

--- a/tests/test_cases/postgres/bytea.in
+++ b/tests/test_cases/postgres/bytea.in
@@ -1,1 +1,1 @@
-select '\xdeadbeef'::bytea
+select x'deadbeef', '\xdeadbeef', '\xdeadbeef'::bytea

--- a/tests/test_cases/postgres/bytea.out
+++ b/tests/test_cases/postgres/bytea.out
@@ -1,4 +1,6 @@
 /* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
 
 SELECT
+  0xdeadbeef,
+  0xdeadbeef,
   CAST(0xdeadbeef AS VARBINARY)

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -1,0 +1,15 @@
+import sqlglot
+
+from dune.harmonizer.dialects.dunesql import DuneSQL
+
+
+def test_parse_hexstring():
+    assert sqlglot.parse_one("SELECT X'deadbeef'", read="trino") == sqlglot.parse_one("SELECT 0xdeadbeef", read=DuneSQL)
+    assert sqlglot.parse_one("SELECT x'deadbeef'", read="postgres") == sqlglot.parse_one(
+        "SELECT 0xdeadbeef", read=DuneSQL
+    )
+
+
+def test_generate_hexstring():
+    assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT X'deadbeef'", read="trino", write=DuneSQL)[0]
+    assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT x'deadbeef'", read="postgres", write=DuneSQL)[0]

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -13,3 +13,5 @@ def test_parse_hexstring():
 def test_generate_hexstring():
     assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT X'deadbeef'", read="trino", write=DuneSQL)[0]
     assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT x'deadbeef'", read="postgres", write=DuneSQL)[0]
+    assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT X'deadbeef'", read=DuneSQL, write=DuneSQL)[0]
+    assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT 0xdeadbeef", read=DuneSQL, write=DuneSQL)[0]

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -2,18 +2,18 @@ import pytest
 
 from dune.harmonizer import translate_postgres, translate_spark
 from tests.cases import postgres_test_cases, spark_test_cases
-from tests.helpers import assert_output, read_test_case
+from tests.helpers import canonicalize, read_test_case
 
 
 @pytest.mark.parametrize("test_case", postgres_test_cases)
 def test_translate_postgres(test_case):
     query, expected_output = read_test_case(test_case)
     output = translate_postgres(query=query, dataset=test_case.dataset)
-    assert_output(output, expected_output)
+    assert expected_output == canonicalize(output)
 
 
 @pytest.mark.parametrize("test_case", spark_test_cases)
 def test_translate_spark(test_case):
     query, expected_output = read_test_case(test_case)
     output = translate_spark(query=query)
-    assert_output(output, expected_output)
+    assert expected_output == canonicalize(output)


### PR DESCRIPTION
Adds a DuneSQL dialect (Trino with a few lines of modifications) and uses it in the final output step. It will parse `0xblablabla` as hex strings and always output parsed hexstrings as `0xblablabla` and not `X'blablabla'`, which is what Trino does.