### PR TITLE
Recognize (U)INT256 types

### DIFF
--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -1,4 +1,4 @@
-from sqlglot import exp
+from sqlglot import TokenType, exp
 from sqlglot.dialects.trino import Trino
 
 
@@ -11,11 +11,15 @@ class DuneSQL(Trino):
         """Text -> Tokens"""
 
         HEX_STRINGS = ["0x", ("X'", "'")]
+        KEYWORDS = Trino.Tokenizer.KEYWORDS | {
+            "UINT256": TokenType.UBIGINT,
+            "INT256": TokenType.BIGINT,
+        }
 
     class Parser(Trino.Parser):
         """Tokens -> AST"""
 
-        pass
+        TYPE_TOKENS = Trino.Parser.TYPE_TOKENS | {TokenType.UBIGINT, TokenType.BIGINT}
 
     class Generator(Trino.Generator):
         """AST -> SQL"""

--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -28,3 +28,8 @@ class DuneSQL(Trino):
             # Output hex strings as 0xdeadbeef
             exp.HexString: lambda self, e: hex(int(e.name)),
         }
+
+        TYPE_MAPPING = Trino.Generator.TYPE_MAPPING | {
+            exp.DataType.Type.UBIGINT: "UINT256",
+            exp.DataType.Type.BIGINT: "INT256",
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-harmonizer"
-version = "0.5.0"
+version = "0.5.1"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -20,3 +20,4 @@ def test_generate_hexstring():
 def test_custom_types():
     sqlglot.parse_one("SELECT CAST(1 AS INT)", read=DuneSQL)
     sqlglot.parse_one("SELECT CAST(1 AS UINT256)", read=DuneSQL)
+    assert "SELECT CAST(1 AS UINT256)" == sqlglot.transpile("SELECT CAST(1 AS UINT256)", read=DuneSQL, write=DuneSQL)[0]

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -18,6 +18,6 @@ def test_generate_hexstring():
 
 
 def test_custom_types():
-    sqlglot.parse_one("SELECT CAST(1 AS INT)", read=DuneSQL)
+    sqlglot.parse_one("SELECT CAST(1 AS INT256)", read=DuneSQL)
     sqlglot.parse_one("SELECT CAST(1 AS UINT256)", read=DuneSQL)
     assert "SELECT CAST(1 AS UINT256)" == sqlglot.transpile("SELECT CAST(1 AS UINT256)", read=DuneSQL, write=DuneSQL)[0]

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -15,3 +15,8 @@ def test_generate_hexstring():
     assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT x'deadbeef'", read="postgres", write=DuneSQL)[0]
     assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT X'deadbeef'", read=DuneSQL, write=DuneSQL)[0]
     assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT 0xdeadbeef", read=DuneSQL, write=DuneSQL)[0]
+
+
+def test_custom_types():
+    sqlglot.parse_one("SELECT CAST(1 AS INT)", read=DuneSQL)
+    sqlglot.parse_one("SELECT CAST(1 AS UINT256)", read=DuneSQL)


### PR DESCRIPTION
Makes `UINT256` the chosen UBIGINT type for DuneSQL (Trino will output `UBIGINT`) and ditto with `INT256` for `BIGINT`.