### PR TITLE
Don't replace Spark's timestamp with from_unixtime anymore

### DIFF
--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -356,14 +356,6 @@ def remove_quotes_around_0x_strings(query):
     return substituted
 
 
-def spark_function_replacements(node):
-    """Replace the Spark timestamp() function with Trino's from_unixtime() function"""
-    query = node.sql(dialect="trino")
-    if "timestamp(" in query.lower():
-        query = re.sub("timestamp", "from_unixtime", query, flags=re.IGNORECASE)
-    return sqlglot.parse_one(query, read="trino")
-
-
 def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
 
@@ -376,7 +368,6 @@ def spark_transforms(query):
         warn_unnest,
         warn_sequence,
         bytea2numeric,
-        spark_function_replacements,
     )
     for f in transforms:
         query_tree = query_tree.transform(f)


### PR DESCRIPTION
We added a fix to SQLGlot upstream for Spark's timestamp function (https://github.com/tobymao/sqlglot/pull/1454). The function is just shorthand for a cast, so now it's translated to a cast. It's still not strictly correct Trino, since the output type is slightly different, so will need to fix that.