### PR TITLE
Remove any lower() function calls around hex strings

### DIFF
--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -290,15 +290,6 @@ def fix_bytearray_param(query):
     return re.sub(pattern, r"{{\1}}", query, flags=re.IGNORECASE)
 
 
-def fix_bytearray_lower(query):
-    """Remove lower function call around '0x...' string literals, and remove the string since we have native hex types.
-
-    This has to happen after SQLGlot, since it will parse a bare 0x as a string literal"""
-    pattern = r"lower\(\s*['\"]?0x(.*?)['\"]?\s*\)"
-    substituted = re.sub(pattern, r"0x\1", query, flags=re.IGNORECASE)
-    return substituted
-
-
 def chain_where(dataset):
     return {
         "gnosis": chain_where_gnosis,

--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -7,7 +7,6 @@ from dune.harmonizer.custom_transforms import (
     add_warnings_and_banner,
     double_quoted_param_left_placeholder,
     double_quoted_param_right_placeholder,
-    fix_bytearray_lower,
     fix_bytearray_param,
     parameter_placeholder,
     postgres_transforms,
@@ -53,7 +52,6 @@ def _translate_query(query, sqlglot_dialect, dataset=None):
 
         # Non-SQLGlot transforms
         query = fix_bytearray_param(query)
-        query = fix_bytearray_lower(query)
 
         return add_warnings_and_banner(query)
 

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -20,13 +20,17 @@ def test_generate_hexstring():
 def test_force_string_with_0x_to_hexstring():
     assert "SELECT 0xdeadbeef" == sqlglot.transpile("SELECT '0xdeadbeef'", read="spark", write=DuneSQL)[0]
     assert (
-        "SELECT 0xdeadbeef, LOWER(0xdeadbeef), 0x1 || 0x2"
+        "SELECT 0xdeadbeef, 0xdeadbeef, 0x1 || 0x2"
         == sqlglot.transpile("SELECT '0xdeadbeef', lower('0xdeadbeef'), '0x1' || '0x2'", read="spark", write=DuneSQL)[0]
     )
     assert (
         "SELECT * FROM table WHERE col = 0xdeadbeef"
         == sqlglot.transpile("SELECT * FROM table WHERE col = '0xdeadbeef'", read="spark", write=DuneSQL)[0]
     )
+
+
+def test_remove_lower_around_hexstring():
+    assert sqlglot.transpile("SELECT lower('0xdeadbeef')", read="spark", write=DuneSQL)[0] == "SELECT 0xdeadbeef"
 
 
 def test_custom_types():


### PR DESCRIPTION
Following up from https://github.com/duneanalytics/harmonizer/pull/26, this PR will remove any lower() function calls directly around a `0x...` string.