### PR TITLE
NLQ postgres syntax only

### DIFF
--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -291,7 +291,7 @@ def postgres_transforms(query, dataset):
         query_tree = query_tree.transform(f)
     return query_tree
 
-def nlq_postgres_transforms(query, dataset):
+def nlq_postgres_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
 
     Each transform takes and returns a sqlglot.Expression"""

--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -291,6 +291,19 @@ def postgres_transforms(query, dataset):
         query_tree = query_tree.transform(f)
     return query_tree
 
+def nlq_postgres_transforms(query, dataset):
+    """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
+
+    Each transform takes and returns a sqlglot.Expression"""
+    query_tree = sqlglot.parse_one(query, read="trino")
+    transforms = (
+        cast_numeric,
+        cast_timestamp_parameters,
+        warn_sequence,
+    )
+    for f in transforms:
+        query_tree = query_tree.transform(f)
+    return query_tree
 
 def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.

--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -38,9 +38,12 @@ def _translate_query(query, sqlglot_dialect, dataset=None, nlq=None):
 
         # Perform custom transformations using SQLGlot's parsed representation
         if nlq:
-            # NLQ uses DuneSQL schemas but needs to translate to Trino without making schema changes
-            query = query.replace("\\x", "0x")
-            query_tree = nlq_postgres_transforms(query)
+            if sqlglot_dialect == "spark":
+                query_tree = spark_transforms(query)
+            elif sqlglot_dialect == "postgres":
+                # NLQ uses DuneSQL schemas but needs to translate to Trino without making schema changes
+                query = query.replace("\\x", "0x")
+                query_tree = nlq_postgres_transforms(query)
         else:
             if sqlglot_dialect == "spark":
                 query_tree = spark_transforms(query)


### PR DESCRIPTION
For the NLQ project, we are feeding in schemas from DuneSQL and then want to translate any errant Postgres syntax which the LLMs love to produce to DuneSQL. 

AFAIK, I can't do that with the harmonizer as id because the postgres translation also applies table changes e.g. injecting the chain into the schema. 

I'm not super familiar yet with the codebase so I took a stab at editing the `_translate_query` method but not sure if this is the best path. 