### PR TITLE
add transform for just syntax

### DIFF
--- a/dune/harmonizer/__init__.py
+++ b/dune/harmonizer/__init__.py
@@ -10,3 +10,8 @@ def translate_postgres(query, dataset):
     """Translate a Dune query from PostgreSQL to DuneSQL"""
     dataset = _clean_dataset(dataset)
     return _translate_query(query, sqlglot_dialect="postgres", dataset=dataset)
+
+def translate_syntax(query, engine):
+    """Translate a Dune query just syntax for either 'spark' or 'postgres'"""
+    return _translate_query(query, sqlglot_dialect="engine", syntax_only=True)
+

--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -291,6 +291,23 @@ def postgres_transforms(query, dataset):
         query_tree = query_tree.transform(f)
     return query_tree
 
+def postgres_transforms_syntax_only(query):
+    """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function. Only to syntax, not to tables.
+
+    Each transform takes and returns a sqlglot.Expression"""
+    query_tree = sqlglot.parse_one(query, read="trino")
+    transforms = (
+        fix_boolean,
+        cast_numeric,
+        cast_timestamp,
+        warn_sequence,
+        bytearray_parameter_fix,
+        rename_amount_column,
+        bytea2numeric,
+    )
+    for f in transforms:
+        query_tree = query_tree.transform(f)
+    return query_tree
 
 def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.


### PR DESCRIPTION
For the LLM project we need a translate function for postgres and spark that only includes syntax changes, and not table schema related changes. To that end I've added `translate_syntax` to `__init__.py` and also `postgres_transforms_syntax_only` to `custom_transforms.py`. 