### PR TITLE
Add `syntax_only` flag to enable opting out of schema changes

### DIFF
--- a/dune/harmonizer/__init__.py
+++ b/dune/harmonizer/__init__.py
@@ -1,4 +1,3 @@
-from dune.harmonizer.custom_transforms import v1_tables_to_v2_tables
 from dune.harmonizer.translate import _clean_dataset, _translate_query
 
 
@@ -13,8 +12,6 @@ def translate_postgres(query, dataset, syntax_only=False):
     By default, this will replace any known v1 to v2 differences in datasets.
     To only translate the syntax, call this with `syntax_only=True`.
     """
-    translated = _translate_query(query, sqlglot_dialect="postgres")
-    if syntax_only:
-        return translated
     dataset = _clean_dataset(dataset)
-    return v1_tables_to_v2_tables(translated, dataset)
+    translated = _translate_query(query, sqlglot_dialect="postgres", dataset=dataset, syntax_only=syntax_only)
+    return translated

--- a/dune/harmonizer/__init__.py
+++ b/dune/harmonizer/__init__.py
@@ -1,3 +1,4 @@
+from dune.harmonizer.custom_transforms import v1_tables_to_v2_tables
 from dune.harmonizer.translate import _clean_dataset, _translate_query
 
 
@@ -6,12 +7,14 @@ def translate_spark(query):
     return _translate_query(query, sqlglot_dialect="spark")
 
 
-def translate_postgres(query, dataset):
-    """Translate a Dune query from PostgreSQL to DuneSQL"""
+def translate_postgres(query, dataset, syntax_only=False):
+    """Translate a Dune query from PostgreSQL to DuneSQL
+
+    By default, this will replace any known v1 to v2 differences in datasets.
+    To only translate the syntax, call this with `syntax_only=True`.
+    """
+    translated = _translate_query(query, sqlglot_dialect="postgres")
+    if syntax_only:
+        return translated
     dataset = _clean_dataset(dataset)
-    return _translate_query(query, sqlglot_dialect="postgres", dataset=dataset)
-
-
-def translate_nlq(query, sqlglot_dialect):
-    """Translate a Dune query from PostgreSQL to DuneSQL"""
-    return _translate_query(query, sqlglot_dialect=sqlglot_dialect, nlq=True)
+    return v1_tables_to_v2_tables(translated, dataset)

--- a/dune/harmonizer/__init__.py
+++ b/dune/harmonizer/__init__.py
@@ -10,3 +10,8 @@ def translate_postgres(query, dataset):
     """Translate a Dune query from PostgreSQL to DuneSQL"""
     dataset = _clean_dataset(dataset)
     return _translate_query(query, sqlglot_dialect="postgres", dataset=dataset)
+
+
+def translate_nlq(query, sqlglot_dialect):
+    """Translate a Dune query from PostgreSQL to DuneSQL"""
+    return _translate_query(query, sqlglot_dialect=sqlglot_dialect, nlq=True)

--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -291,7 +291,7 @@ def postgres_transforms(query, dataset):
         query_tree = query_tree.transform(f)
     return query_tree
 
-def nlq_postgres_transforms(query, dataset):
+def nlq_postgres_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
 
     Each transform takes and returns a sqlglot.Expression"""

--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -291,6 +291,19 @@ def postgres_transforms(query, dataset):
         query_tree = query_tree.transform(f)
     return query_tree
 
+def nlq_postgres_transforms(query, dataset):
+    """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
+
+    Each transform takes and returns a sqlglot.Expression"""
+    query_tree = sqlglot.parse_one(query, read="trino")
+    transforms = (
+        cast_numeric,
+        cast_timestamp_parameters,
+        warn_sequence,
+    )
+    for f in transforms:
+        query_tree = query_tree.transform(f)
+    return query_tree
 
 def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.

--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -291,6 +291,7 @@ def postgres_transforms(query, dataset):
         query_tree = query_tree.transform(f)
     return query_tree
 
+
 def nlq_postgres_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
 
@@ -304,6 +305,7 @@ def nlq_postgres_transforms(query):
     for f in transforms:
         query_tree = query_tree.transform(f)
     return query_tree
+
 
 def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.

--- a/dune/harmonizer/table_replacements.py
+++ b/dune/harmonizer/table_replacements.py
@@ -2,8 +2,6 @@ import re
 
 import sqlglot
 
-from dune.harmonizer.dialects.dunesql import DuneSQL
-
 
 def postgres_table_replacements(dataset):
     """Return a function to do table replacements for Postgres -> DuneSQL, with appropriate dataset"""
@@ -15,7 +13,7 @@ def postgres_table_replacements(dataset):
         if not isinstance(node, sqlglot.exp.Table):
             return node
 
-        query = node.sql(dialect=DuneSQL)
+        query = node.sql(dialect="trino")
 
         spellbook_mapping = {
             "erc20.ERC20_evt_Transfer": "erc20_ethereum.evt_Transfer",
@@ -34,7 +32,7 @@ def postgres_table_replacements(dataset):
             # if an alias is used for the table, add it back
             if node.unalias().alias is not None:
                 spell_table = spell_table + " as " + node.unalias().alias
-            return sqlglot.parse_one(spell_table, read=DuneSQL)
+            return sqlglot.parse_one(spell_table, read="trino")
 
         # else if decoded table, then add _ethereum to the table name
         elif any(decoded in node.name for decoded in ["_evt_", "_call_"]):
@@ -42,7 +40,7 @@ def postgres_table_replacements(dataset):
             # if an alias is used, add it back
             if node.unalias().alias is not None:
                 chain_added_table = chain_added_table + " as " + node.unalias().alias
-            return sqlglot.parse_one(chain_added_table, read=DuneSQL)
+            return sqlglot.parse_one(chain_added_table, read="trino")
 
         return node
 

--- a/dune/harmonizer/table_replacements.py
+++ b/dune/harmonizer/table_replacements.py
@@ -2,6 +2,8 @@ import re
 
 import sqlglot
 
+from dune.harmonizer.dialects.dunesql import DuneSQL
+
 
 def postgres_table_replacements(dataset):
     """Return a function to do table replacements for Postgres -> DuneSQL, with appropriate dataset"""
@@ -13,7 +15,7 @@ def postgres_table_replacements(dataset):
         if not isinstance(node, sqlglot.exp.Table):
             return node
 
-        query = node.sql(dialect="trino")
+        query = node.sql(dialect=DuneSQL)
 
         spellbook_mapping = {
             "erc20.ERC20_evt_Transfer": "erc20_ethereum.evt_Transfer",
@@ -32,7 +34,7 @@ def postgres_table_replacements(dataset):
             # if an alias is used for the table, add it back
             if node.unalias().alias is not None:
                 spell_table = spell_table + " as " + node.unalias().alias
-            return sqlglot.parse_one(spell_table, read="trino")
+            return sqlglot.parse_one(spell_table, read=DuneSQL)
 
         # else if decoded table, then add _ethereum to the table name
         elif any(decoded in node.name for decoded in ["_evt_", "_call_"]):
@@ -40,7 +42,7 @@ def postgres_table_replacements(dataset):
             # if an alias is used, add it back
             if node.unalias().alias is not None:
                 chain_added_table = chain_added_table + " as " + node.unalias().alias
-            return sqlglot.parse_one(chain_added_table, read="trino")
+            return sqlglot.parse_one(chain_added_table, read=DuneSQL)
 
         return node
 

--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -1,5 +1,4 @@
 import re
-
 import sqlglot
 from sqlglot import ParseError
 

--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -1,4 +1,5 @@
 import re
+
 import sqlglot
 from sqlglot import ParseError
 
@@ -7,10 +8,10 @@ from dune.harmonizer.custom_transforms import (
     double_quoted_param_left_placeholder,
     double_quoted_param_right_placeholder,
     fix_bytearray_param,
+    nlq_postgres_transforms,
     parameter_placeholder,
     postgres_transforms,
     spark_transforms,
-    nlq_postgres_transforms,
 )
 from dune.harmonizer.dialects.dunesql import DuneSQL
 from dune.harmonizer.errors import DuneTranslationError

--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -38,9 +38,12 @@ def _translate_query(query, sqlglot_dialect, dataset=None, nlq=None):
 
         # Perform custom transformations using SQLGlot's parsed representation
         if nlq:
-            # NLQ uses DuneSQL schemas but needs to translate to Trino without making schema changes
-            query = query.replace("\\x", "0x")
-            query_tree = nlq_postgres_transforms(query)
+            if sqlglot_dialect == "spark":
+                query_tree = spark_transforms(query)
+            elif sqlglot_dialect == "postgres":
+                # NLQ uses DuneSQL schemas but needs to translate to Trino without making schema changes
+                query = query.replace("\\x", "0x")
+                query_tree = nlq_postgres_transforms(query)
         else:
             if sqlglot_dialect == "spark":
                 query_tree = spark_transforms(query)

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -39,3 +39,17 @@ spark_test_cases = [
     SparkTestCase("test_cases/spark/explode.in", "test_cases/spark/explode.out"),
     SparkTestCase("test_cases/spark/bytea2numeric_0x.in", "test_cases/spark/bytea2numeric_0x.out"),
 ]
+
+
+@dataclass
+class NLQTestCase:
+    in_filename: str
+    out_filename: str
+    dataset: str
+
+
+postgres_cases_to_remove = [
+    PostgresTestCase("test_cases/postgres/dex.in", "test_cases/postgres/dex_ethereum.out", "ethereum"),
+    PostgresTestCase("test_cases/postgres/dex.in", "test_cases/postgres/dex_polygon.out", "polygon"),
+]
+nlq_test_cases = [case for case in postgres_test_cases if case not in postgres_cases_to_remove]

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dune.harmonizer import translate_postgres, translate_spark, translate_nlq
-from tests.cases import postgres_test_cases, spark_test_cases
+from tests.cases import postgres_test_cases, spark_test_cases, nlq_test_cases
 from tests.helpers import canonicalize, read_test_case
 
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,7 +1,7 @@
 import pytest
 
-from dune.harmonizer import translate_postgres, translate_spark, translate_nlq
-from tests.cases import postgres_test_cases, spark_test_cases, nlq_test_cases
+from dune.harmonizer import translate_nlq, translate_postgres, translate_spark
+from tests.cases import nlq_test_cases, postgres_test_cases, spark_test_cases
 from tests.helpers import canonicalize, read_test_case
 
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -17,3 +17,10 @@ def test_translate_spark(test_case):
     query, expected_output = read_test_case(test_case)
     output = translate_spark(query=query)
     assert canonicalize(output) == expected_output
+
+
+@pytest.mark.parametrize("test_case", postgres_test_cases)
+def test_translate_nlq_postgres(test_case):
+    query, expected_output = read_test_case(test_case)
+    output = _translate_query(query=query, sqlglot_dialect="postgres", nlq=True)
+    assert canonicalize(output) == expected_output

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -19,7 +19,7 @@ def test_translate_spark(test_case):
     assert canonicalize(output) == expected_output
 
 
-@pytest.mark.parametrize("test_case", postgres_test_cases)
+@pytest.mark.parametrize("test_case", nlq_test_cases)
 def test_translate_nlq(test_case):
     query, expected_output = read_test_case(test_case)
     output = translate_nlq(query=query, sqlglot_dialect="postgres")

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dune.harmonizer import translate_nlq, translate_postgres, translate_spark
+from dune.harmonizer import translate_postgres, translate_spark
 from tests.cases import nlq_test_cases, postgres_test_cases, spark_test_cases
 from tests.helpers import canonicalize, read_test_case
 
@@ -22,5 +22,5 @@ def test_translate_spark(test_case):
 @pytest.mark.parametrize("test_case", nlq_test_cases)
 def test_translate_nlq(test_case):
     query, expected_output = read_test_case(test_case)
-    output = translate_nlq(query=query, sqlglot_dialect="postgres")
+    output = translate_postgres(query=query, dataset=None, syntax_only=True)
     assert canonicalize(output) == expected_output

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dune.harmonizer import translate_postgres, translate_spark
+from dune.harmonizer import translate_postgres, translate_spark, translate_nlq
 from tests.cases import postgres_test_cases, spark_test_cases
 from tests.helpers import canonicalize, read_test_case
 
@@ -20,7 +20,7 @@ def test_translate_spark(test_case):
 
 
 @pytest.mark.parametrize("test_case", postgres_test_cases)
-def test_translate_nlq_postgres(test_case):
+def test_translate_nlq(test_case):
     query, expected_output = read_test_case(test_case)
-    output = _translate_query(query=query, sqlglot_dialect="postgres", nlq=True)
+    output = translate_nlq(query=query, sqlglot_dialect="postgres")
     assert canonicalize(output) == expected_output


### PR DESCRIPTION
Implements the suggestion I made in https://github.com/duneanalytics/harmonizer/pull/34#pullrequestreview-1403252189 and merges it into that branch (so not into the main branch).

This adds a `syntax_only` flag to the `translate_postgres` function, such that we only do the v1->v2 table/schema related changes if it has been set to `True` (which it now is by default).
