### PR TITLE
Make explicit casts of string -> bool, datetime idempotent

### DIFF
--- a/dune/harmonizer/dialects/dunesql.py
+++ b/dune/harmonizer/dialects/dunesql.py
@@ -102,6 +102,7 @@ def cast_boolean_strings(expression: exp.Expression):
         if isinstance(e, exp.Literal)
         and e.args["is_string"]
         and (e.this.lower() == "true" or e.this.lower() == "false")
+        and (not isinstance(e.parent, exp.Cast))
         else e
     )
 
@@ -121,7 +122,10 @@ def cast_date_strings(expression: exp.Expression):
     Spark and Postgres implicitly convert strings like this into timestamps when needed"""
     return expression.transform(
         lambda e: exp.Cast(this=e, to=exp.DataType.build("timestamp"))
-        if isinstance(e, exp.Literal) and e.args["is_string"] and _looks_like_timestamp(e.this)
+        if isinstance(e, exp.Literal)
+        and e.args["is_string"]
+        and _looks_like_timestamp(e.this)
+        and (not isinstance(e.parent, exp.Cast))
         else e
     )
 

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -128,6 +128,14 @@ def test_cast_bool_strings():
         "SELECT TRUE, FALSE, TRUE = TRUE, 'word'"
         == sqlglot.transpile("SELECT 'true', 'false', 'true' = true, 'word'", read="postgres", write=DuneSQL)[0]
     )
+    # must be idempotent
+    assert (
+        "SELECT TRUE"
+        == sqlglot.transpile(
+            sqlglot.transpile("SELECT 'true'", read="postgres", write=DuneSQL)[0],
+            read=DuneSQL,
+        )[0]
+    )
 
 
 def test_looks_like_timestamp():
@@ -142,6 +150,14 @@ def test_cast_timestamp_strings():
     assert (
         "SELECT CAST('2023-01-01' AS TIMESTAMP)"
         == sqlglot.transpile("SELECT '2023-01-01'", read="postgres", write=DuneSQL)[0]
+    )
+    # must be idempotent
+    assert (
+        "SELECT CAST('2023-01-01' AS TIMESTAMP)"
+        == sqlglot.transpile(
+            sqlglot.transpile("SELECT '2023-01-01'", read="postgres", write=DuneSQL)[0],
+            read=DuneSQL,
+        )[0]
     )
 
 


### PR DESCRIPTION
Now we don't get nested calls of casts to the same type.