### PR TITLE
Make table replacements more robust

### DIFF
--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -118,7 +118,7 @@ def chain_where_blockchain(node, blockchain):
     # add a blockchain = 'ethereum' to the WHERE statement for trades, tokens, and prices tables.
     required_tables = [
         "nft.trades",
-        "dex.in.trades",
+        "dex.trades",
         "tokens.erc20",
         "tokens.nft",
         "prices.usd",
@@ -143,7 +143,7 @@ def dex_trades_fixes(node):
     """Fixes to dex.trades"""
     # doesn't matter if subquery or not, it will replace the found filter.
     if node.key == "select":
-        if "dex.in.trades" in node.sql(dialect="trino").replace('"', ""):
+        if "dex.trades" in node.sql(dialect="trino").replace('"', ""):
             # change exchange_contract_address to project_contract_address
             final_where = node.sql(dialect="trino").replace("exchange_contract_address", "project_contract_address")
 

--- a/dune/harmonizer/table_replacements.py
+++ b/dune/harmonizer/table_replacements.py
@@ -29,13 +29,12 @@ def postgres_table_replacements(dataset):
                 return sqlglot.parse_one(f"{to_db}.{to_table} as {table_node.alias}", read="trino")
             return sqlglot.parse_one(f"{to_db}.{to_table}", read="trino")
 
-        # if decoded table, then add _{dataset} to the table name
-        if any(decoded in table_node.name.lower() for decoded in ["_evt_", "_call_"]):
-            chain_added_table = table_node.sql(dialect="trino").split(".")[0] + "_" + dataset + "." + table_node.name
-            # if an alias is used, add it back
-            if table_node.unalias().alias is not None:
-                chain_added_table = chain_added_table + " as " + table_node.unalias().alias
-            return sqlglot.parse_one(chain_added_table, read="trino")
+        # if decoded table, add _{dataset} to the table name
+        if any(decoded in table_node.name.lower() for decoded in ("_evt_", "_call_")):
+            to_db, to_table = f"{table_node.db}_{dataset}", table_node.name
+            if table_node.alias != "":
+                return sqlglot.parse_one(f"{to_db}.{to_table} as {table_node.alias}", read="trino")
+            return sqlglot.parse_one(f"{to_db}.{to_table}", read="trino")
 
         return table_node
 

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -16,6 +16,7 @@ postgres_test_cases = [
     PostgresTestCase("test_cases/postgres/bytea.in", "test_cases/postgres/bytea.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/bytea2numeric.in", "test_cases/postgres/bytea2numeric.out", "ethereum"),
     PostgresTestCase("test_cases/param.in", "test_cases/param.out", "ethereum"),
+    PostgresTestCase("test_cases/postgres/table_replacement.in", "test_cases/postgres/table_replacement.out", "optimism"),
 ]
 
 
@@ -52,5 +53,6 @@ class NLQTestCase:
 postgres_cases_to_remove = [
     PostgresTestCase("test_cases/postgres/dex.in", "test_cases/postgres/dex_ethereum.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/dex.in", "test_cases/postgres/dex_polygon.out", "polygon"),
+    PostgresTestCase("test_cases/postgres/table_replacement.in", "test_cases/postgres/table_replacement.out", "optimism"),
 ]
 nlq_test_cases = [case for case in postgres_test_cases if case not in postgres_cases_to_remove]

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -16,7 +16,9 @@ postgres_test_cases = [
     PostgresTestCase("test_cases/postgres/bytea.in", "test_cases/postgres/bytea.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/bytea2numeric.in", "test_cases/postgres/bytea2numeric.out", "ethereum"),
     PostgresTestCase("test_cases/param.in", "test_cases/param.out", "ethereum"),
-    PostgresTestCase("test_cases/postgres/table_replacement.in", "test_cases/postgres/table_replacement.out", "optimism"),
+    PostgresTestCase(
+        "test_cases/postgres/table_replacement.in", "test_cases/postgres/table_replacement.out", "optimism"
+    ),
 ]
 
 
@@ -53,6 +55,8 @@ class NLQTestCase:
 postgres_cases_to_remove = [
     PostgresTestCase("test_cases/postgres/dex.in", "test_cases/postgres/dex_ethereum.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/dex.in", "test_cases/postgres/dex_polygon.out", "polygon"),
-    PostgresTestCase("test_cases/postgres/table_replacement.in", "test_cases/postgres/table_replacement.out", "optimism"),
+    PostgresTestCase(
+        "test_cases/postgres/table_replacement.in", "test_cases/postgres/table_replacement.out", "optimism"
+    ),
 ]
 nlq_test_cases = [case for case in postgres_test_cases if case not in postgres_cases_to_remove]

--- a/tests/test_cases/postgres/dex_ethereum.out
+++ b/tests/test_cases/postgres/dex_ethereum.out
@@ -10,6 +10,8 @@ FROM (
     SELECT
       *
     FROM dex."trades"
+    WHERE
+      blockchain = 'ethereum'
   ) AS a
 ) AS d /* test comment */
 LEFT JOIN prices.usd AS p

--- a/tests/test_cases/postgres/dex_polygon.out
+++ b/tests/test_cases/postgres/dex_polygon.out
@@ -10,6 +10,8 @@ FROM (
     SELECT
       *
     FROM dex."trades"
+    WHERE
+      blockchain = 'polygon'
   ) AS a
 ) AS d /* test comment */
 LEFT JOIN prices.usd AS p

--- a/tests/test_cases/postgres/table_replacement.in
+++ b/tests/test_cases/postgres/table_replacement.in
@@ -1,1 +1,1 @@
-SELECT * FROM erc20."ERC20_evt_Transfer", erc20.ERC20_evt_Transfer x
+SELECT * FROM erc20."ERC20_evt_Transfer", erc20.ERC20_evt_Transfer x, aave."AaveCollateralVaultProxy_evt_DeployVault"

--- a/tests/test_cases/postgres/table_replacement.in
+++ b/tests/test_cases/postgres/table_replacement.in
@@ -1,0 +1,1 @@
+SELECT * FROM erc20."ERC20_evt_Transfer", erc20.ERC20_evt_Transfer

--- a/tests/test_cases/postgres/table_replacement.in
+++ b/tests/test_cases/postgres/table_replacement.in
@@ -1,1 +1,1 @@
-SELECT * FROM erc20."ERC20_evt_Transfer", erc20.ERC20_evt_Transfer
+SELECT * FROM erc20."ERC20_evt_Transfer", erc20.ERC20_evt_Transfer x

--- a/tests/test_cases/postgres/table_replacement.in
+++ b/tests/test_cases/postgres/table_replacement.in
@@ -1,1 +1,1 @@
-SELECT * FROM erc20."ERC20_evt_Transfer", erc20.ERC20_evt_Transfer x, aave."AaveCollateralVaultProxy_evt_DeployVault"
+SELECT * FROM erc20."ERC20_evt_Transfer", erc721.ERC721_evt_Transfer as x, aave."AaveCollateralVaultProxy_evt_DeployVault"

--- a/tests/test_cases/postgres/table_replacement.out
+++ b/tests/test_cases/postgres/table_replacement.out
@@ -1,0 +1,5 @@
+/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
+
+SELECT
+  *
+FROM erc20_optimism.evt_Transfer, erc20_optimism.evt_Transfer

--- a/tests/test_cases/postgres/table_replacement.out
+++ b/tests/test_cases/postgres/table_replacement.out
@@ -2,4 +2,4 @@
 
 SELECT
   *
-FROM erc20_optimism.evt_Transfer, erc20_optimism.evt_Transfer
+FROM erc20_optimism.evt_Transfer, erc20_optimism.evt_Transfer AS x

--- a/tests/test_cases/postgres/table_replacement.out
+++ b/tests/test_cases/postgres/table_replacement.out
@@ -2,4 +2,4 @@
 
 SELECT
   *
-FROM erc20_optimism.evt_Transfer, erc20_optimism.evt_Transfer AS x
+FROM erc20_optimism.evt_Transfer, erc20_optimism.evt_Transfer AS x, aave_optimism.AaveCollateralVaultProxy_evt_DeployVault

--- a/tests/test_cases/postgres/table_replacement.out
+++ b/tests/test_cases/postgres/table_replacement.out
@@ -2,4 +2,4 @@
 
 SELECT
   *
-FROM erc20_optimism.evt_Transfer, erc20_optimism.evt_Transfer AS x, aave_optimism.AaveCollateralVaultProxy_evt_DeployVault
+FROM erc20_optimism.evt_Transfer, erc721_ethereum.evt_Transfer AS x, aave_optimism.AaveCollateralVaultProxy_evt_DeployVault


### PR DESCRIPTION
Fixes #40

As reported in #40, table replacements don't happen if they're quoted, as we do exact string matching on the `db."table_name"` concatenation.

This PR fixes that by making the replacement more robust, using the exp.Table structure from the parsed AST.