### PR TITLE
Update SQLGlot after breaking change to explode transform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "dune"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-sqlglot = "^11.6.0"
+sqlglot = "^11.7.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.2"

--- a/tests/test_cases/spark/explode.out
+++ b/tests/test_cases/spark/explode.out
@@ -3,4 +3,4 @@
 SELECT
   exploded
 FROM foo
-CROSS JOIN UNNEST(column) AS array_column(exploded)
+CROSS JOIN UNNEST(column) AS _u(exploded)

--- a/tests/test_cases/spark/params.out
+++ b/tests/test_cases/spark/params.out
@@ -9,4 +9,4 @@ FROM UNNEST(SEQUENCE(
     CAST(SUBSTR(CAST(CAST('{{2 - End Date}}' AS TIMESTAMP) AS VARCHAR), 1, 10) AS DATE)
   ),
   INTERVAL '1' {{3 - Time Granularity}}
-) /* WARNING: Check out the docs for example of time series generation: https://dune.com/docs/query/syntax-differences/ */) AS array_column(time)
+) /* WARNING: Check out the docs for example of time series generation: https://dune.com/docs/query/syntax-differences/ */) AS _u(time)


### PR DESCRIPTION
After https://github.com/tobymao/sqlglot/pull/1501 was merged and released, the transform we're doing is almost redundant. For some reason, it still fails on Postgres, so we can't remove our transform just yet, will make sure that's fixed upstream.