### PR TITLE
Use sqlglot's `replace_tables` when replacing tables

### DIFF
--- a/dune/harmonizer/dunesql/optimize.py
+++ b/dune/harmonizer/dunesql/optimize.py
@@ -16,7 +16,6 @@ def optimize(expr, schema):
         expression=optimizer.qualify_columns(
             expression=expr,
             schema=schema,
-            expand_laterals=False,
         ),
         schema=schema,
         annotators=annotators,

--- a/dune/harmonizer/table_replacements.py
+++ b/dune/harmonizer/table_replacements.py
@@ -1,6 +1,6 @@
 import sqlglot
 from sqlglot import to_identifier
-from sqlglot.expressions import TableAlias
+from sqlglot.expressions import TableAlias, replace_tables
 
 
 def postgres_table_replacements(dataset):
@@ -13,25 +13,18 @@ def postgres_table_replacements(dataset):
         if not isinstance(table_node, sqlglot.exp.Table):
             return table_node
 
-        spellbook_mapping = {
-            ("erc20", "erc20_evt_transfer"): (f"erc20_{dataset}", "evt_Transfer"),
-            ("bep20", "bep20_evt_transfer"): ("erc20_bnb", "evt_Transfer"),
-            ("erc721", "erc721_evt_transfer"): ("erc721_ethereum", "evt_Transfer"),
-            ("bep20", "tokens"): ("tokens", "erc20"),
-            ("erc20", "tokens"): ("tokens", "erc20"),
-            ("erc721", "tokens"): ("tokens", "nft"),
-            ("prices", "layer1_usd_btc"): ("prices", "usd"),
-            ("prices", "layer1_usd_eth"): ("prices", "usd"),
+        mapping = {
+            "erc20.erc20_evt_transfer": f"erc20_{dataset}.evt_Transfer",
+            "bep20.bep20_evt_transfer": "erc20_bnb.evt_Transfer",
+            "erc721.erc721_evt_transfer": "erc721_ethereum.evt_Transfer",
+            "bep20.tokens": "tokens.erc20",
+            "erc20.tokens": "tokens.erc20",
+            "erc721.tokens": "tokens.nft",
+            "prices.layer1_usd_btc": "prices.usd",
+            "prices.layer1_usd_eth": "prices.usd",
         }
-        table = table_node.db.lower(), table_node.name.lower()
-        replacement = spellbook_mapping.get(table)
-        if replacement is not None:
-            to_db, to_table = replacement
-            return sqlglot.exp.Table(
-                this=to_identifier(to_table),
-                db=to_identifier(to_db),
-                alias=TableAlias(this=to_identifier(table_node.alias)) if table_node.alias else None,
-            )
+
+        table_node = replace_tables(table_node, mapping)
 
         # if decoded table, add _{dataset} to the table name
         if any(decoded in table_node.name.lower() for decoded in ("_evt_", "_call_")):

--- a/dune/harmonizer/table_replacements.py
+++ b/dune/harmonizer/table_replacements.py
@@ -24,7 +24,17 @@ def postgres_table_replacements(dataset):
             "prices.layer1_usd_eth": "prices.usd",
         }
 
-        table_node = replace_tables(table_node, mapping)
+        # Do a case insensitive lookup in the replacement mapping
+        table_node_case_insensitive = sqlglot.exp.Table(
+            this=to_identifier(table_node.name.lower()),
+            db=to_identifier(table_node.db.lower() if table_node.db else None),
+            alias=TableAlias(this=to_identifier(table_node.alias.lower())) if table_node.alias else None,
+        )
+        replaced_table_node = replace_tables(table_node_case_insensitive, mapping)
+
+        # Did replace
+        if replaced_table_node != table_node_case_insensitive:
+            return replaced_table_node
 
         # if decoded table, add _{dataset} to the table name
         if any(decoded in table_node.name.lower() for decoded in ("_evt_", "_call_")):

--- a/dune/harmonizer/table_replacements.py
+++ b/dune/harmonizer/table_replacements.py
@@ -13,7 +13,7 @@ def postgres_table_replacements(dataset):
         if not isinstance(table_node, sqlglot.exp.Table):
             return table_node
 
-        mapping = {
+        spellbook_mapping = {
             "erc20.erc20_evt_transfer": f"erc20_{dataset}.evt_Transfer",
             "bep20.bep20_evt_transfer": "erc20_bnb.evt_Transfer",
             "erc721.erc721_evt_transfer": "erc721_ethereum.evt_Transfer",
@@ -30,7 +30,7 @@ def postgres_table_replacements(dataset):
             db=to_identifier(table_node.db.lower() if table_node.db else None),
             alias=TableAlias(this=to_identifier(table_node.alias.lower())) if table_node.alias else None,
         )
-        replaced_table_node = replace_tables(table_node_case_insensitive, mapping)
+        replaced_table_node = replace_tables(table_node_case_insensitive, spellbook_mapping)
 
         # Did replace
         if replaced_table_node != table_node_case_insensitive:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "dune"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-sqlglot = "^12.3.0"
+sqlglot = "^12.4.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.2"

--- a/tests/dunesql/test_optimize.py
+++ b/tests/dunesql/test_optimize.py
@@ -16,5 +16,5 @@ def test_optimize_cast_with_schema():
 def test_fail_with_qualified_columns():
     dune_sql_expr = sqlglot.parse_one("SELECT col FROM tbl", read=DuneSQL)
     optimized = optimize(dune_sql_expr, schema={"tbl": {"x": "int"}})
-    with pytest.raises(sqlglot.errors.OptimizeError, match="Unknown table: '' for column 'col'"):
+    with pytest.raises(sqlglot.errors.OptimizeError, match="Column 'col' could not be resolved"):
         validate_qualify_columns(optimized)


### PR DESCRIPTION
SQLGlot has a helper `replace_tables` which can be used to replace table names in a `from`, given a mapping of table names to replacement table names.

There are some limitations (e.g. https://github.com/tobymao/sqlglot/issues/1622) but this is definitely better than regex'ing!

https://github.com/tobymao/sqlglot/blob/966dfbb990a12e14bab83b18f554c0f36ed8bae3/sqlglot/expressions.py#L5282-L5308