### PR TITLE
ORDER BY nulls are last

### DIFF
--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -41,7 +41,7 @@ def _translate_query(query, sqlglot_dialect, dataset=None, syntax_only=False, ta
 
     # Parse query using SQLGlot
     try:
-        query_tree = sqlglot.parse_one(query, read=sqlglot_dialect)
+        query_tree = sqlglot.parse_one(query, read=sqlglot_dialect, null_ordering="nulls_are_last")
     except ParseError as e:
         # SQLGlot inserts terminal style colors to emphasize error location.
         # We remove these, as they mess up the formatting.

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -25,6 +25,8 @@ postgres_test_cases = [
     PostgresTestCase("test_cases/postgres/cross_join.in", "test_cases/postgres/cross_join.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/median.in", "test_cases/postgres/median.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/explicit_cast.in", "test_cases/postgres/explicit_cast.out", "ethereum"),
+    PostgresTestCase("test_cases/postgres/explicit_cast.in", "test_cases/postgres/explicit_cast.out", "ethereum"),
+    PostgresTestCase("test_cases/postgres/order_by.in", "test_cases/postgres/order_by.out", "ethereum"),
 ]
 
 

--- a/tests/test_cases/postgres/order_by.in
+++ b/tests/test_cases/postgres/order_by.in
@@ -1,0 +1,6 @@
+SELECT
+    month,
+    collection,
+    num_trades,
+    RANK() OVER (PARTITION BY month ORDER BY num_trades DESC) AS rank
+  FROM monthly_trades

--- a/tests/test_cases/postgres/order_by.out
+++ b/tests/test_cases/postgres/order_by.out
@@ -1,0 +1,8 @@
+/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
+
+SELECT
+    month,
+    collection,
+    num_trades,
+    RANK() OVER (PARTITION BY month ORDER BY num_trades DESC) AS rank
+  FROM monthly_trades


### PR DESCRIPTION
@vegarsti, I'd like to propose overrriding the default setting for [nulls_ordering](https://github.com/tobymao/sqlglot/blob/1a88b17ce0b9d5c71d48f53eacab63e011dc170b/sqlglot/parser.py#LL73C20-L73C20) to nulls_are_last from nulls_are_first. 

We see NULLS ARE FIRST show up in a lot of natural language queries and I think it usually makes more sense for nulls to come last. 