### PR TITLE
Remove success header from translated queries

### DIFF
--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -330,7 +330,7 @@ def v2_transforms(query_tree):
     return query_tree
 
 
-def add_warnings_and_banner(query):
+def add_warnings(query):
     """Add a success banner at the top, and look for a few cases of things we don't fix and add a warning if present"""
     if "lower('{{" in query.lower():
         query = (
@@ -346,12 +346,7 @@ def add_warnings_and_banner(query):
             "\n\n"
         ) + query
 
-    # add note at top
-    return (
-        "/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ "
-        "or reach out in the #dune-sql Discord channel. */"
-        "\n\n"
-    ) + query
+    return query
 
 
 def parameter_placeholder(p):

--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -4,7 +4,7 @@ import sqlglot
 from sqlglot import ParseError
 
 from dune.harmonizer.custom_transforms import (
-    add_warnings_and_banner,
+    add_warnings,
     fix_bytearray_param,
     parameter_placeholder,
     v1_tables_to_v2_tables,
@@ -85,4 +85,4 @@ def _translate_query(query, sqlglot_dialect, dataset=None, syntax_only=False, ta
     # Non-SQLGlot transforms
     query = fix_bytearray_param(query)
 
-    return add_warnings_and_banner(query)
+    return add_warnings(query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-harmonizer"
-version = "0.23.0"
+version = "0.24.0"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/test_cases/param.out
+++ b/tests/test_cases/param.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   {{ param }}
 FROM foo

--- a/tests/test_cases/postgres/0x_strings_leading_0.out
+++ b/tests/test_cases/postgres/0x_strings_leading_0.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   0xdeadbeef,
   0x0010,

--- a/tests/test_cases/postgres/aliases.out
+++ b/tests/test_cases/postgres/aliases.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   1 AS a,
   2 AS b,

--- a/tests/test_cases/postgres/bytea.out
+++ b/tests/test_cases/postgres/bytea.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   0xdeadbeef,
   0xdeadbeef,

--- a/tests/test_cases/postgres/bytea2numeric.out
+++ b/tests/test_cases/postgres/bytea2numeric.out
@@ -1,4 +1,2 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   BYTEARRAY_TO_BIGINT(data)

--- a/tests/test_cases/postgres/cross_join.out
+++ b/tests/test_cases/postgres/cross_join.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   x,
   dt

--- a/tests/test_cases/postgres/dex_ethereum.out
+++ b/tests/test_cases/postgres/dex_ethereum.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   project AS "Project",
   SUM(CAST(amount_usd AS DOUBLE)) AS usd_volume

--- a/tests/test_cases/postgres/dex_polygon.out
+++ b/tests/test_cases/postgres/dex_polygon.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   project AS "Project",
   SUM(CAST(amount_usd AS DOUBLE)) AS usd_volume

--- a/tests/test_cases/postgres/explicit_cast.out
+++ b/tests/test_cases/postgres/explicit_cast.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   TRY_CAST(x AS INTEGER) AS x,
   TRY_CAST(y AS VARCHAR) AS y,

--- a/tests/test_cases/postgres/median.out
+++ b/tests/test_cases/postgres/median.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   tx_index,
   APPROX_PERCENTILE(tx_index, 0.5)

--- a/tests/test_cases/postgres/now.out
+++ b/tests/test_cases/postgres/now.out
@@ -1,4 +1,2 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   CURRENT_TIMESTAMP

--- a/tests/test_cases/postgres/order_by.out
+++ b/tests/test_cases/postgres/order_by.out
@@ -1,8 +1,6 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
-    month,
-    collection,
-    num_trades,
-    RANK() OVER (PARTITION BY month ORDER BY num_trades DESC) AS rank
-  FROM monthly_trades
+  month,
+  collection,
+  num_trades,
+  RANK() OVER (PARTITION BY month ORDER BY num_trades DESC) AS rank
+FROM monthly_trades

--- a/tests/test_cases/postgres/table_replacement.out
+++ b/tests/test_cases/postgres/table_replacement.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   *
 FROM erc20_optimism.evt_Transfer, erc721_ethereum.evt_Transfer AS x, aave_optimism.AaveCollateralVaultProxy_evt_DeployVault

--- a/tests/test_cases/spark/0x_strings.out
+++ b/tests/test_cases/spark/0x_strings.out
@@ -1,4 +1,2 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   0xdeadbeef

--- a/tests/test_cases/spark/0x_strings_leading_0.out
+++ b/tests/test_cases/spark/0x_strings_leading_0.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   0xdeadbeef,
   0x0010,

--- a/tests/test_cases/spark/array_index.out
+++ b/tests/test_cases/spark/array_index.out
@@ -1,4 +1,2 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   array_col[1]

--- a/tests/test_cases/spark/bytea2numeric_0x.out
+++ b/tests/test_cases/spark/bytea2numeric_0x.out
@@ -1,4 +1,2 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   BYTEARRAY_TO_BIGINT(0xdeadbeef)

--- a/tests/test_cases/spark/bytea_lower.out
+++ b/tests/test_cases/spark/bytea_lower.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   0xdeadbeef,
   'hello'

--- a/tests/test_cases/spark/bytea_param.out
+++ b/tests/test_cases/spark/bytea_param.out
@@ -1,4 +1,2 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   {{ foo }}

--- a/tests/test_cases/spark/datediff.out
+++ b/tests/test_cases/spark/datediff.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   DATE_DIFF(
     'day',

--- a/tests/test_cases/spark/explode.out
+++ b/tests/test_cases/spark/explode.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   exploded
 FROM foo

--- a/tests/test_cases/spark/interval.out
+++ b/tests/test_cases/spark/interval.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   evt_block_time + INTERVAL '1' day * term AS can_claim_day,
   term,

--- a/tests/test_cases/spark/interval_week.out
+++ b/tests/test_cases/spark/interval_week.out
@@ -1,4 +1,2 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   NOW() - (64 * INTERVAL '7' day)

--- a/tests/test_cases/spark/matic.out
+++ b/tests/test_cases/spark/matic.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 WITH transfers_to AS (
   SELECT
     "to" AS wallet,

--- a/tests/test_cases/spark/params.out
+++ b/tests/test_cases/spark/params.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   time
 FROM UNNEST(SEQUENCE(

--- a/tests/test_cases/spark/quoted_column.out
+++ b/tests/test_cases/spark/quoted_column.out
@@ -1,5 +1,3 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   "to"
 FROM foo

--- a/tests/test_cases/spark/timestamp.out
+++ b/tests/test_cases/spark/timestamp.out
@@ -1,4 +1,2 @@
-/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
-
 SELECT
   CAST(n AS TIMESTAMP)


### PR DESCRIPTION
The flow in the app is sufficiently clear that the call to harmonizer did work, as is the use of the library: If there's no error, it succeeded.