### PR TITLE
Don't cast columns with amount in name to DOUBLE

### DIFF
--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -218,14 +218,6 @@ def bytearray_parameter_fix(node):
     return node
 
 
-def cast_numeric(node):
-    """if a column has amount/value in the name, cast to double"""
-    if node.key == "column":
-        if any(val in node.name.lower() for val in ("amount", "value")):
-            return sqlglot.parse_one("cast(" + node.name + " as double)", read="trino")
-    return node
-
-
 def cast_timestamp_parameters(node):
     """Look for parameters with 'date' or 'time' in, and cast these as timestamps"""
     if node.key == "literal":
@@ -288,7 +280,6 @@ def v1_transforms(query_tree):
 
     Each transform takes and returns a sqlglot.Expression"""
     transforms = (
-        cast_numeric,
         cast_timestamp_parameters,
         warn_sequence,
         bytearray_parameter_fix,
@@ -321,7 +312,6 @@ def v2_transforms(query_tree):
 
     Each transform takes and returns a sqlglot.Expression"""
     transforms = (
-        cast_numeric,
         cast_timestamp_parameters,
         warn_sequence,
     )

--- a/dune/harmonizer/dunesql/dunesql.py
+++ b/dune/harmonizer/dunesql/dunesql.py
@@ -41,8 +41,8 @@ class DuneSQL(Trino):
                     rename_bytea2numeric_to_bytearray_to_bigint,
                     cast_boolean_strings,
                     cast_date_strings,
+                    replace_0x_strings_with_hex_strings,
                     # Optimizations
-                    replace_0x_strings_with_hex_strings,  # should happen at parse time?
                     remove_calls_on_hex_strings,
                     concat_of_hex_string_to_bytearray_concat,
                     pipe_of_hex_strings_to_bytearray_concat,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-harmonizer"
-version = "0.24.0"
+version = "0.25.0"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/test_cases/postgres/dex_ethereum.out
+++ b/tests/test_cases/postgres/dex_ethereum.out
@@ -1,6 +1,6 @@
 SELECT
   project AS "Project",
-  SUM(CAST(amount_usd AS DOUBLE)) AS usd_volume
+  SUM(amount_usd) AS usd_volume
 FROM (
   SELECT
     *

--- a/tests/test_cases/postgres/dex_polygon.out
+++ b/tests/test_cases/postgres/dex_polygon.out
@@ -1,6 +1,6 @@
 SELECT
   project AS "Project",
-  SUM(CAST(amount_usd AS DOUBLE)) AS usd_volume
+  SUM(amount_usd) AS usd_volume
 FROM (
   SELECT
     *

--- a/tests/test_cases/spark/matic.out
+++ b/tests/test_cases/spark/matic.out
@@ -1,7 +1,7 @@
 WITH transfers_to AS (
   SELECT
     "to" AS wallet,
-    SUM(TRY_CAST(CAST(value AS DOUBLE) AS DOUBLE)) / 1e18 AS amount
+    SUM(TRY_CAST(value AS DOUBLE)) / 1e18 AS amount
   FROM erc20_polygon.evt_Transfer
   WHERE
     contract_address = 0xea1132120ddcdda2f119e99fa7a27a0d036f7ac9
@@ -12,7 +12,7 @@ WITH transfers_to AS (
     "from" AS wallet,
     (
       -1
-    ) * SUM(TRY_CAST(CAST(value AS DOUBLE) AS DOUBLE)) / 1e18 AS amount
+    ) * SUM(TRY_CAST(value AS DOUBLE)) / 1e18 AS amount
   FROM erc20_polygon.evt_Transfer
   WHERE
     contract_address = 0xea1132120ddcdda2f119e99fa7a27a0d036f7ac9
@@ -29,13 +29,12 @@ WITH transfers_to AS (
 )
 SELECT
   wallet AS "user",
-  SUM(CAST(amount AS DOUBLE)) AS amount,
+  SUM(amount) AS amount,
   0 AS ethdebt
 FROM all_opers
 GROUP BY
   1
 HAVING
-  SUM(CAST(amount AS DOUBLE)) >= 0.1
-  AND wallet <> 0x0000000000000000000000000000000000000000
+  SUM(amount) >= 0.1 AND wallet <> 0x0000000000000000000000000000000000000000
 ORDER BY
   2 DESC


### PR DESCRIPTION
We did this at first because a lot of columns with `amount` were strings, and Spark supports addition with numeric strings, Trino does not. But now these columns are usually numeric.