### PR TITLE
Downgrade python dependency to ^3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "dune"}]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.10"
 sqlglot = "^13"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
I'd like to pull the harmonizer into the `spellbook-trino` repository to run query translations.
(currently Alex has been running a local instance of the query-translator and sending requests to it, but that server code isn't publicly available, see [translate_query.py](https://github.com/duneanalytics/spellbook-trino/blob/e4d1a08fe24bd9cfcde025a0fae6c74db2a39233/translate_query.py) for context)

The  `spellbook-trino` repo is python 3.10 however, so I'd like to downgrade the dependency here to 3.10
I've tested the harmonizer locally with 3.10 and 3.11 and both seemed to work fine.
Tested with:
```
poetry install && poetry run pytest
```