### PR TITLE
Translate Spark's null safe indexing into null safe element_at function

### DIFF
--- a/dune/harmonizer/custom_transforms.py
+++ b/dune/harmonizer/custom_transforms.py
@@ -253,6 +253,21 @@ def cast_division_to_double(node):
     )
 
 
+def null_safe_indexing(node):
+    """Ensure compatibility with Spark's null safe indexing
+
+    Spark uses null safe indexing, but Trino doesn't, so we transform to use Trino's null safe indexing function,
+    `element_at`.
+
+    We also add 1 to the index used, since Spark arrays are 0-indexed, while Trino's are 1-indexed.
+    """
+    return node.transform(
+        lambda e: exp.Anonymous(this="element_at", expressions=[e.this, e.expressions[0] + 1])
+        if isinstance(e, exp.Bracket)
+        else e
+    )
+
+
 def rename_amount_column(query):
     """Rename the usd_amount column"""
     return sqlglot.parse_one(query.sql(dialect="trino").replace("usd_amount", "amount_usd"), read="trino")
@@ -325,6 +340,7 @@ def v2_transforms(query_tree):
         cast_timestamp_parameters,
         warn_sequence,
         cast_division_to_double,
+        null_safe_indexing,
     )
     for f in transforms:
         query_tree = query_tree.transform(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-harmonizer"
-version = "0.29.0"
+version = "0.30.0"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/test_cases/spark/array_index.in
+++ b/tests/test_cases/spark/array_index.in
@@ -1,1 +1,1 @@
-select array_col[0 + 0]
+select array_col[0 + 0], arr[2].foo.bar, arr[i]

--- a/tests/test_cases/spark/array_index.out
+++ b/tests/test_cases/spark/array_index.out
@@ -1,2 +1,4 @@
 SELECT
-  array_col[1]
+  ELEMENT_AT(array_col, 0 + 0 + 1),
+  ELEMENT_AT(arr, 2 + 1).foo.bar,
+  ELEMENT_AT(arr, i + 1)

--- a/tests/test_cases/spark/matic.out
+++ b/tests/test_cases/spark/matic.out
@@ -11,8 +11,10 @@ WITH transfers_to AS (
   SELECT
     "from" AS wallet,
     (
-      -1
-    ) * SUM(TRY_CAST(value AS DOUBLE)) / CAST(1e18 AS DOUBLE) AS amount
+      (
+        -1
+      ) * SUM(TRY_CAST(value AS DOUBLE))
+    ) / CAST(1e18 AS DOUBLE) AS amount
   FROM erc20_polygon.evt_Transfer
   WHERE
     contract_address = 0xea1132120ddcdda2f119e99fa7a27a0d036f7ac9


### PR DESCRIPTION
Fixes #75.

A lot of Dune queries rely on Spark's indexing operation being null safe, i.e. it returns `null` if the array isn't long enough, instead of failing at execution, which is what Trino does. A lot of Solana queries, where there's a lot of working with columns of arrays, and columns of arrays of structs, rely on this feature of Spark.

To better accommodate it, we change an indexing operation into Trino's null safe [`element_at`](https://trino.io/docs/current/functions/array.html#array-functions) function. Further, we increment the index by 1, since Spark is 0-indexed while Trino is 1-indexed.