### PR TITLE
Propagate all SqlglotErrors by catching and raising with error message

### DIFF
--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dune.harmonizer import translate_postgres, translate_spark
+from dune.harmonizer.errors import DuneTranslationError
 from tests.cases import nlq_test_cases, postgres_test_cases, spark_test_cases
 from tests.helpers import canonicalize, read_test_case
 
@@ -39,3 +40,8 @@ def test_translate_with_mapping():
         },
     )
     assert canonicalize(expected_output) in canonicalize(output)
+
+
+def test_translate_errors():
+    with pytest.raises(DuneTranslationError):
+        translate_postgres(query="select encode(account, 'hex')", dataset="ethereum")


### PR DESCRIPTION
In the frontend, we don't get the error message from the service unless it's a `ParseError` raised when we do the first parse of the query. But SQLGlot errors may come elsewhere, such as at SQL generation time, like in the test here.