### PR TITLE
Add workaround for tokenization error

### DIFF
--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -58,6 +58,7 @@ def _translate_query(query, sqlglot_dialect, dataset=None, syntax_only=False, ta
     # because it's just a general byte array notation. But we want to always parse it as a hex string.
     if sqlglot_dialect == "postgres":
         query = query.replace(r"'\x", "x'")
+        query = query.replace("x''", "'x'")  # SQLGlot is unable to tokenize this so work around
         try:
             query = transform_interval_cast(query)
         except ParseError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-harmonizer"
-version = "0.32.1"
+version = "0.32.2"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -32,6 +32,7 @@ postgres_test_cases = [
     PostgresTestCase("test_cases/postgres/interval.in", "test_cases/postgres/interval.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/unnest_array.in", "test_cases/postgres/unnest_array.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/unnest_table.in", "test_cases/postgres/unnest_table.out", "ethereum"),
+    PostgresTestCase("test_cases/postgres/concat_x.in", "test_cases/postgres/concat_x.out", "ethereum"),
 ]
 
 

--- a/tests/test_cases/postgres/concat_x.in
+++ b/tests/test_cases/postgres/concat_x.in
@@ -1,0 +1,1 @@
+select CONCAT('\x', 'lol')

--- a/tests/test_cases/postgres/concat_x.out
+++ b/tests/test_cases/postgres/concat_x.out
@@ -1,0 +1,5 @@
+SELECT
+  CONCAT(
+    CAST(COALESCE(COALESCE('x', ''), '') AS VARCHAR),
+    CAST(COALESCE(COALESCE('lol', ''), '') AS VARCHAR)
+  )


### PR DESCRIPTION
The added test case throws a `ValueError`