### PR TITLE
Don't increment array indices in Postgres

### DIFF
--- a/tests/cases.py
+++ b/tests/cases.py
@@ -33,6 +33,7 @@ postgres_test_cases = [
     PostgresTestCase("test_cases/postgres/unnest_array.in", "test_cases/postgres/unnest_array.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/unnest_table.in", "test_cases/postgres/unnest_table.out", "ethereum"),
     PostgresTestCase("test_cases/postgres/concat_x.in", "test_cases/postgres/concat_x.out", "ethereum"),
+    PostgresTestCase("test_cases/postgres/array.in", "test_cases/postgres/array.out", "ethereum"),
 ]
 
 

--- a/tests/test_cases/postgres/array.in
+++ b/tests/test_cases/postgres/array.in
@@ -1,0 +1,1 @@
+select col[1]

--- a/tests/test_cases/postgres/array.out
+++ b/tests/test_cases/postgres/array.out
@@ -1,0 +1,2 @@
+SELECT
+  col[1]


### PR DESCRIPTION
Fixes #86. Fix in https://github.com/tobymao/sqlglot/pull/1782 was included in SQLGlot 16.1.4 https://github.com/tobymao/sqlglot/commit/d0d23bcb28a96f078d691d3b3459211d7621f172