### PR TITLE
fix nulls first regression

### DIFF
--- a/dune/harmonizer/dunesql/dunepostgres.py
+++ b/dune/harmonizer/dunesql/dunepostgres.py
@@ -1,0 +1,9 @@
+from sqlglot.dialects.postgres import Postgres
+
+
+class DunePostgres(Postgres):
+    """
+    Overwrite Postgres dialect to nulls are last
+    """
+
+    NULL_ORDERING = "nulls_are_last"

--- a/dune/harmonizer/translate.py
+++ b/dune/harmonizer/translate.py
@@ -13,6 +13,7 @@ from dune.harmonizer.custom_transforms import (
     v1_transforms,
     v2_transforms,
 )
+from dune.harmonizer.dunesql.dunepostgres import DunePostgres
 from dune.harmonizer.dunesql.dunesql import DuneSQL
 from dune.harmonizer.errors import DuneTranslationError
 from dune.harmonizer.table_replacements import spellbook_mapping
@@ -72,7 +73,10 @@ def _translate_query(query, sqlglot_dialect, dataset=None, syntax_only=False, ta
 
     # Parse query using SQLGlot
     try:
-        query_tree = sqlglot.parse_one(query, read=sqlglot_dialect)
+        if sqlglot_dialect == "postgres":
+            query_tree = sqlglot.parse_one(query, read=DunePostgres)
+        else:
+            query_tree = sqlglot.parse_one(query, read=sqlglot_dialect)
     except ParseError as e:
         raise DuneTranslationError(_handle_parse_error(parameter_map, e))
     except SqlglotError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-harmonizer"
-version = "0.34.2"
+version = "0.34.3"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/test_cases/postgres/order_by.out
+++ b/tests/test_cases/postgres/order_by.out
@@ -2,5 +2,5 @@ SELECT
   month,
   collection,
   num_trades,
-  RANK() OVER (PARTITION BY month ORDER BY num_trades DESC NULLS FIRST) AS rank
+  RANK() OVER (PARTITION BY month ORDER BY num_trades DESC) AS rank
 FROM monthly_trades


### PR DESCRIPTION
Null ordering is large in the postgres dialect and previously we overrode this with https://github.com/duneanalytics/harmonizer/pull/66 but it was reverting when we bumped sqlglot versions https://github.com/duneanalytics/harmonizer/pull/82

The only way I see to get around this is to make a new Dialect and inherit Postgres and edit NULL_ORDERING on that. 

```
class Postgres(Dialect):
    INDEX_OFFSET = 1
    NULL_ORDERING = "nulls_are_large"
```
https://github.com/tobymao/sqlglot/blob/46b5dfa09bba7c339dd8b0bd077455946dec8d8d/sqlglot/dialects/postgres.py#L211
